### PR TITLE
Bump min versions of some of the deps

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 875b34f524149531d9bbac5a0dd44c8cc7affa3cc0d11e80a70be1d125a8a726
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - py3dep = py3dep.cli:cli
@@ -31,10 +31,10 @@ requirements:
     - pygeoutils >=0.13.2
     - python >=3.8
     - rasterio >=1.2
-    - rioxarray >=0.10
+    - rioxarray >=0.11
     - scipy
     - shapely >=1.7
-    - xarray >=0.18
+    - xarray >=2022.03.0
 
 test:
   imports:


### PR DESCRIPTION
It seems that the previous build of py3dep was not successful since correct version cannot be detected.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
